### PR TITLE
Added option to specify extra HTML classes for the invisible ReCaptcha button

### DIFF
--- a/src/hbehr.recaptcha.unittest/UnitTests.cs
+++ b/src/hbehr.recaptcha.unittest/UnitTests.cs
@@ -190,5 +190,14 @@ namespace hbehr.recaptcha.unittest
             string captchaString = captcha.ToHtmlString();
             Assert.AreEqual("<button class='g-recaptcha' data-sitekey='my-public-key' data-callback='callback'>SUBMIT</button><script src='https://www.google.com/recaptcha/api.js?hl=pt-BR'></script>", captchaString);
         }
-    }
+
+        [Test]
+        public void AssertScriptInvisibleDivIsCorrectWithAdditionalClassesOverrideConfiguration()
+        {
+           ReCaptcha.Configure("my-public-key", "my-secret-key", ReCaptchaLanguage.EnglishUs);
+           IHtmlString captcha = ReCaptcha.GetInvisibleCaptcha("callback", "SUBMIT", additionalClasses: new []{ "btn", "btn-autosize" });
+           string captchaString = captcha.ToHtmlString();
+           Assert.AreEqual("<button class='g-recaptcha btn btn-autosize' data-sitekey='my-public-key' data-callback='callback'>SUBMIT</button><script src='https://www.google.com/recaptcha/api.js?hl=en'></script>", captchaString);
+        }
+   }
 }

--- a/src/hbehr.recaptcha/ReCaptcha.cs
+++ b/src/hbehr.recaptcha/ReCaptcha.cs
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web;
@@ -47,9 +49,9 @@ namespace hbehr.recaptcha
             return _reCaptcha.GetCaptcha(language);
         }
 
-        public static IHtmlString GetInvisibleCaptcha(string callback, string buttonText, ReCaptchaLanguage? language = null)
+        public static IHtmlString GetInvisibleCaptcha(string callback, string buttonText, ReCaptchaLanguage? language = null, IEnumerable<string> additionalClasses = null)
         {
-            return _reCaptcha.GetInvisibleCaptcha(callback, buttonText, language);
+            return _reCaptcha.GetInvisibleCaptcha(callback, buttonText, language, additionalClasses);
         }
 
         public static bool ValidateCaptcha(string response, WebProxy proxy = null)

--- a/src/hbehr.recaptcha/ReCaptchaObject.cs
+++ b/src/hbehr.recaptcha/ReCaptchaObject.cs
@@ -25,7 +25,9 @@ using hbehr.recaptcha.Exceptions;
 using hbehr.recaptcha.Internazionalization;
 using hbehr.recaptcha.WebInterface;
 using System;
+using System.Collections.Generic;
 using System.Configuration;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web;
@@ -90,7 +92,7 @@ namespace hbehr.recaptcha
             _configured = true;
             _secretKey = secretKey;
             _captchaDiv = string.Format("<div class='g-recaptcha' data-sitekey='{0}'></div><script src='https://www.google.com/recaptcha/api.js{{0}}'></script>", publicKey);
-            _invisibleCaptchaDiv = string.Format("<button class='g-recaptcha' data-sitekey='{0}' data-callback='{{1}}'>{{2}}</button><script src='https://www.google.com/recaptcha/api.js{{0}}'></script>", publicKey);
+            _invisibleCaptchaDiv = string.Format("<button class='{{1}}' data-sitekey='{0}' data-callback='{{2}}'>{{3}}</button><script src='https://www.google.com/recaptcha/api.js{{0}}'></script>", publicKey);
         }
 
         private string GetHlCode(ReCaptchaLanguage? language)
@@ -112,10 +114,15 @@ namespace hbehr.recaptcha
             return new HtmlString(string.Format(_captchaDiv, GetHlCode(language)));
         }
 
-        internal IHtmlString GetInvisibleCaptcha(string callback, string buttonText, ReCaptchaLanguage? language)
+        internal IHtmlString GetInvisibleCaptcha(string callback, string buttonText, ReCaptchaLanguage? language, IEnumerable<string> additionalClasses)
         {
             CheckIfIamConfigured();
-            return new HtmlString(string.Format(_invisibleCaptchaDiv, GetHlCode(language), callback, buttonText));
+            var classes = new List<string> {"g-recaptcha"};
+            if (additionalClasses != null)
+            {
+              classes.AddRange(additionalClasses);
+            }
+            return new HtmlString(string.Format(_invisibleCaptchaDiv, GetHlCode(language), string.Join(" ", classes), callback, buttonText));
         }
 
         internal bool ValidateResponse(IReChaptaWebInterface webInterface, string response)


### PR DESCRIPTION
I've added an option to specify extra classes to the invisible ReCaptcha button. I'm currently using your library, but cannot switch to the invisible ReCaptcha because it breaks the CSS layout that we're using.

Please let me know whether or not you would like to add this feature, and if you want me to change something in my PR.