### PR TITLE
Fix auto language for cultures with parent cultures.

### DIFF
--- a/src/hbehr.recaptcha.unittest/ExtensionTests.cs
+++ b/src/hbehr.recaptcha.unittest/ExtensionTests.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using hbehr.recaptcha.Internazionalization;
+using NUnit.Framework;
+
+namespace hbehr.recaptcha.unittest
+{
+	[TestFixture]
+	public class ExtensionTests
+	{
+		[Test]
+		public void NoExceptionWhenChinese()
+		{
+			Assert.DoesNotThrow(() =>
+			{
+				CultureInfo.CurrentUICulture = new CultureInfo("zh-CN");
+
+				ReCaptchaLanguage.Auto.GetLanguage();
+			});
+		}
+	}
+}

--- a/src/hbehr.recaptcha.unittest/ExtensionTests.cs
+++ b/src/hbehr.recaptcha.unittest/ExtensionTests.cs
@@ -16,6 +16,17 @@ namespace hbehr.recaptcha.unittest
 
 				ReCaptchaLanguage.Auto.GetLanguage();
 			});
+		}	
+		
+		[Test]
+		public void NoExceptionWhenNorwegianBokmal()
+		{
+			Assert.DoesNotThrow(() =>
+			{
+				CultureInfo.CurrentUICulture = new CultureInfo("nb-NO");
+
+				ReCaptchaLanguage.Auto.GetLanguage();
+			});
 		}
 	}
 }

--- a/src/hbehr.recaptcha.unittest/hbehr.recaptcha.unittest.csproj
+++ b/src/hbehr.recaptcha.unittest/hbehr.recaptcha.unittest.csproj
@@ -53,6 +53,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ExtensionTests.cs" />
     <Compile Include="TimedTests.cs" />
     <Compile Include="UnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/hbehr.recaptcha/Internazionalization/LanguageAttributeHelper.cs
+++ b/src/hbehr.recaptcha/Internazionalization/LanguageAttributeHelper.cs
@@ -54,9 +54,20 @@ namespace hbehr.recaptcha.Internazionalization
             var language = GetLanguageByCulture(culture.ToString());
 
             if (language.HasValue)
-                return language;  
+                return language;
+
+            var parentCulture = culture.Parent;
+            while (parentCulture != CultureInfo.InvariantCulture)
+            {
+                language = GetLanguageByCulture(parentCulture.ToString());
+
+                if (language.HasValue)
+                    return language;
+
+                parentCulture = parentCulture.Parent;
+            }
             
-            return GetLanguageByCulture((culture.Parent != CultureInfo.InvariantCulture ? culture.Parent : culture).ToString());
+            return ReCaptchaLanguage.EnglishUs;
         }
 
         private static ReCaptchaLanguage? ConvertLangType(MemberInfo memberInfo)

--- a/src/hbehr.recaptcha/Internazionalization/LanguageAttributeHelper.cs
+++ b/src/hbehr.recaptcha/Internazionalization/LanguageAttributeHelper.cs
@@ -51,6 +51,11 @@ namespace hbehr.recaptcha.Internazionalization
 
         public static ReCaptchaLanguage? GetLanguageByCulture(CultureInfo culture)
         {
+            var language = GetLanguageByCulture(culture.ToString());
+
+            if (language.HasValue)
+                return language;  
+            
             return GetLanguageByCulture((culture.Parent != CultureInfo.InvariantCulture ? culture.Parent : culture).ToString());
         }
 


### PR DESCRIPTION
When "ReCaptchaLanguage.Auto" is used and the underlying CultureInfo.CurrentUICulture is "zh-CN" or "zh-TW" the code runs into a endless loop resulting in a StackoverflowException.

The reason behind this is, that the code tries to use the parent culture, which is "zh-CHS", but this doesn't exist as an attribute. For this case I now check first the culture itself and only if that doesn't return a valid/existing language will it check with the current culture's parent.