### PR TITLE
Removed NewtonSoft.Json dependency

### DIFF
--- a/src/hbehr.recaptcha/ReCaptchaJsonResponse.cs
+++ b/src/hbehr.recaptcha/ReCaptchaJsonResponse.cs
@@ -21,15 +21,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-using Newtonsoft.Json;
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 
 namespace hbehr.recaptcha
 {
+    [DataContract]
     internal class ReCaptchaJsonResponse
     {
-        [JsonProperty("success")]
+        [DataMember(Name = "success")]
         internal bool Success { get; set; }
-        [JsonProperty("error-codes")]
+        [DataMember(Name = "error-codes")]
         internal string[] ErrorCodes { get; set; }
+
+        internal static ReCaptchaJsonResponse DeserializeResponse(string response)
+        {
+            var serializer = new DataContractJsonSerializer(typeof(ReCaptchaJsonResponse));
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(response);
+            writer.Flush();
+            stream.Position = 0;
+
+            return (ReCaptchaJsonResponse)serializer.ReadObject(stream);
+        }
     }
 }

--- a/src/hbehr.recaptcha/WebCommunication/GoogleWebPost.cs
+++ b/src/hbehr.recaptcha/WebCommunication/GoogleWebPost.cs
@@ -21,10 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+using System.CodeDom;
 using hbehr.recaptcha.WebInterface;
-using Newtonsoft.Json;
 using System.IO;
 using System.Net;
+using System.Runtime.Serialization.Json;
 using System.Web;
 
 namespace hbehr.recaptcha.WebCommunication
@@ -58,7 +60,7 @@ namespace hbehr.recaptcha.WebCommunication
         private ReCaptchaJsonResponse GetAnswer(WebRequest webRequest)
         {
             var webResponse = webRequest.GetResponse();
-            return JsonConvert.DeserializeObject<ReCaptchaJsonResponse>(ReadAnswerFromWebResponse(webResponse));
+            return ReCaptchaJsonResponse.DeserializeResponse(ReadAnswerFromWebResponse(webResponse));
         }
 
         private string ReadAnswerFromWebResponse(WebResponse webResponse)

--- a/src/hbehr.recaptcha/WebCommunication/GoogleWebPostAsync.cs
+++ b/src/hbehr.recaptcha/WebCommunication/GoogleWebPostAsync.cs
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 using hbehr.recaptcha.WebInterface;
-using Newtonsoft.Json;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -60,7 +59,7 @@ namespace hbehr.recaptcha.WebCommunication
         private async Task<ReCaptchaJsonResponse> GetAnswerAsync(WebRequest webRequest)
         {
             var webResponse = webRequest.GetResponseAsync();
-            return JsonConvert.DeserializeObject<ReCaptchaJsonResponse>(await ReadAnswerFromWebResponseAsync(webResponse));
+            return ReCaptchaJsonResponse.DeserializeResponse(await ReadAnswerFromWebResponseAsync(webResponse));
         }
 
         private async Task<string> ReadAnswerFromWebResponseAsync(Task<WebResponse> webResponse)

--- a/src/hbehr.recaptcha/hbehr.recaptcha.csproj
+++ b/src/hbehr.recaptcha/hbehr.recaptcha.csproj
@@ -36,11 +36,9 @@
     <DefineConstants>NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/hbehr.recaptcha/packages.config
+++ b/src/hbehr.recaptcha/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
After submitting issue #18 I tried to solve the problem myself.
Since NewtonSoft.Json is only used to parse the JSON responses of the Recaptcha API, the easiest way to fix it was to write a simple deserializing Method and remove the dependency.